### PR TITLE
Fix LinkedIn link and redirect images

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,23 +8,23 @@
 
 [![Mail Badge](https://img.shields.io/badge/Mail1-9c38d1?style=flat&logo=Gmail&logoColor=white)](mailto:aitor.izuzquiza@gmail.com)
 [![Mail Badge](https://img.shields.io/badge/Mail2-9c38d1?style=flat&logo=Gmail&logoColor=white)](mailto:100428965@alumnos.uc3m.es)
-[![LinkedIn Badge](https://img.shields.io/badge/Linkedin-9c38d1?style=flat&logo=LinkedIn&logoColor=white)](linkedin.com/in/aitorizuzquiza)
+[![LinkedIn Badge](https://img.shields.io/badge/Linkedin-9c38d1?style=flat&logo=LinkedIn&logoColor=white)](https://linkedin.com/in/aitorizuzquiza)
 
 ## 🔥 My Github Streak
 <p align="center">
-    <img src="https://github-readme-streak-stats.herokuapp.com/?user=Skaidus&theme=dark&hide_border=true" />
+    <a href=https://github.com/Skaidus/Skaidus><img src="https://github-readme-streak-stats.herokuapp.com/?user=Skaidus&theme=dark&hide_border=true"></a>
 </p>
 
 ## 🏆 Github Profile Trophy
 <p align="center">
-    <img src="https://github-profile-trophy.vercel.app/?username=Skaidus&theme=darkhub&margin-w=15&row=1&no-frame=true" />
+    <a href=https://github.com/Skaidus/Skaidus><img src="https://github-profile-trophy.vercel.app/?username=Skaidus&theme=darkhub&margin-w=15&row=1&no-frame=true"></a>
 </p>
 
 ## 📊 My Github Stats
 
 <p align="center">
-    <img src="https://github-readme-stats.vercel.app/api?username=Skaidus&count_private=true&hide_border=true&card_width=300&show_icons=true&theme=tokyonight&hide=["contribs","prs"]"/>
-   <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=Skaidus&layout=compact&hide_border=true&card_width=400&langs_count=10&theme=tokyonight"/>
+    <a href=https://github.com/Skaidus/Skaidus><img src="https://github-readme-stats.vercel.app/api?username=Skaidus&count_private=true&hide_border=true&card_width=300&show_icons=true&theme=tokyonight&hide=["contribs","prs"]"></a>
+    <a href=https://github.com/Skaidus/Skaidus><img src="https://github-readme-stats.vercel.app/api/top-langs/?username=Skaidus&layout=compact&hide_border=true&card_width=400&langs_count=10&theme=tokyonight"></a>
 </p>
 
-<img src="https://activity-graph.herokuapp.com/graph?username=Skaidus&theme=react-dark&hide_border=true" />
+<a href=https://github.com/Skaidus/Skaidus><img src="https://activity-graph.herokuapp.com/graph?username=Skaidus&theme=react-dark&hide_border=true"></a>


### PR DESCRIPTION
Images now just link to the profile repo instead of an empty, badly rendered outside image.